### PR TITLE
clear voter info before adding new results

### DIFF
--- a/chapter3/app/javascripts/app.js
+++ b/chapter3/app/javascripts/app.js
@@ -71,6 +71,7 @@ window.lookupVoterInfo = function() {
     contractInstance.voterDetails.call(address).then(function(v) {
       $("#tokens-bought").html("Total Tokens bought: " + v[0].toString());
       let votesPerCandidate = v[1];
+      $("#votes-cast").empty();
       $("#votes-cast").append("Votes cast per candidate: <br>");
       let allCandidates = Object.keys(candidates);
       for(let i=0; i < allCandidates.length; i++) {


### PR DESCRIPTION
Subsequent "lookup"s stack voter info. PR clears voter info before adding new info.
![screen shot 2017-05-17 at 3 11 25 pm](https://cloud.githubusercontent.com/assets/1433595/26174012/7f34de18-3b13-11e7-9657-2f19c0f70db6.jpg)
