### PR TITLE
Add solc@^0.4.18 dependency

### DIFF
--- a/chapter1/package.json
+++ b/chapter1/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "ethereumjs-testrpc": "^3.0.3",
-    "web3": "^0.18.2"
+    "web3": "^0.18.2",
+    "solc": "^0.4.18"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
In Chapter1, we cannot run `solc = require('solc')`, since there is no definition npm module called `solc` in this package.json. So I added a `solc` that fits the version defined by `Voting.sol`.

Please review and confirm my pull request.